### PR TITLE
feat(upload_to_hq): optional project-space arg + positive confirm wording (1.1.3)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nova",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Build, edit, compile, and deploy CommCare apps from Claude Code",
   "author": { "name": "voidcraft-labs" },
   "homepage": "https://docs.commcare.app/claude-code",

--- a/README.md
+++ b/README.md
@@ -27,4 +27,4 @@ Full details: [docs.commcare.app/mcp/api-keys](https://docs.commcare.app/mcp/api
 - `/nova:edit <app_id> "<instruction>"` — edit an existing app
 - `/nova:list` — list your apps
 - `/nova:show <app_id>` — blueprint summary
-- `/nova:upload <app_id> <domain> [app_name]` — deploy to CommCare HQ
+- `/nova:upload_to_hq <app_id or name> [project space]` — deploy to CommCare HQ (names a space to upload straight there, otherwise confirms the target first)

--- a/skills/upload_to_hq/SKILL.md
+++ b/skills/upload_to_hq/SKILL.md
@@ -1,73 +1,82 @@
 ---
 name: upload_to_hq
-description: Upload an existing Nova app to CommCare HQ using the user's stored API key. Confirms the target domain with the user before uploading.
-argument-hint: <app_id or name>
+description: Upload an existing Nova app to CommCare HQ using the user's stored API key. Name a project space to upload straight there; otherwise it confirms the target with the user first.
+argument-hint: <app_id or name> [project space]
 ---
 
 # Task
 
-The user wants to upload app "$ARGUMENTS" to CommCare HQ. Follow these steps.
+The user wants to upload an app to CommCare HQ. The input is `$ARGUMENTS`.
 
-## 1. Resolve the argument to exactly one app
+## 1. Parse the arguments
 
-`$ARGUMENTS` may be either a Firestore app id (a short alphanumeric string,
-typically ~20 chars) or a search phrase for the app's name.
+`$ARGUMENTS` is the app to upload, optionally followed by a target project space:
 
-- Looks like a Firestore id → call Nova's `get_app` tool with `{app_id: "$ARGUMENTS"}`.
-- Otherwise → call Nova's `search_apps` tool with `{query: "$ARGUMENTS"}`.
-  - If the response has zero matches: tell the user no app matched and stop.
-  - If multiple matches: show them as a numbered list with
+- **App** — a Firestore app id (a short alphanumeric string, ~20 chars) or a
+  search phrase for the app's name (a name may contain spaces).
+- **Project space (optional)** — a CommCare domain slug (lowercase, hyphenated,
+  no spaces), given as the FINAL token. Treat a trailing token as the target
+  space only when it reads like a domain slug and what precedes it is still a
+  complete app reference; otherwise treat the whole of `$ARGUMENTS` as the app
+  and leave the space unset. If the user quoted the app (e.g.
+  `"Client Registry" connect-ace-prod`), the quoted part is the app and the
+  trailing token is the space.
+
+Call the space parsed here the **explicit target** — it may be unset.
+
+## 2. Resolve the argument to exactly one app
+
+The app reference may be a Firestore app id or a name search phrase.
+
+- Looks like a Firestore id → call Nova's `get_app` tool with `{app_id: "<app>"}`.
+- Otherwise → call Nova's `search_apps` tool with `{query: "<app>"}`.
+  - Zero matches → tell the user no app matched and stop.
+  - Multiple matches → show them as a numbered list with
     `<N>. **<App Name>** (<app_id>) — <N> modules, <M> forms, updated <date>`
-    and ask which one to upload. Wait for their answer before continuing.
-  - If exactly one match: use it.
+    and ask which one. Wait for their answer before continuing.
+  - Exactly one → use it.
 
-Throughout the rest of the flow, refer to the app as **"App Name" (app_id)**
-so the user sees both the human-readable name and the stable identifier.
+Throughout, refer to the app as **"App Name" (app_id)** so the user sees both
+the friendly name and the stable id.
 
-## 2. Check the HQ connection and resolve the target space
+## 3. Pick the path
 
-Call Nova's `get_hq_connection` tool with no arguments. The response has
-`configured` and `available_domains` (every project space this API key can
-upload to — an unscoped key reaches several).
+- **An explicit target was supplied →** go straight to step 4 and upload to it.
+  Naming a space IS the user's confirmation — do NOT ask again, and do NOT call
+  `get_hq_connection`. (If the space turns out to be unreachable, step 5's
+  `domain_not_authorized` handling recovers it in one turn.)
 
-- `configured: false` → tell the user: "CommCare HQ isn't connected yet. Add
-  your HQ API key in Settings before uploading." Stop.
-- `configured: true` → resolve which space to upload to:
+- **No explicit target →** check the connection and confirm:
+  - Call Nova's `get_hq_connection` (no arguments). `configured: false` → tell
+    the user "CommCare HQ isn't connected yet. Add your HQ API key in Settings
+    before uploading." and stop.
   - One entry in `available_domains` → that's the target.
   - Multiple entries → the user chooses; never pick for them. Show the spaces as
-    a numbered list — `<N>. **<displayName>** (<name>)` — and ask which one to
-    upload to. Wait for their answer before continuing. (There is no stored
-    default: a multi-space key's target is a per-upload choice.)
+    a numbered list — `<N>. **<displayName>** (<name>)` — and ask which one. Wait
+    for their answer. (There is no stored default — a multi-space key's target is
+    a per-upload choice.)
+  - Then **confirm** before uploading (substitute real values; `<space>` is the
+    chosen `name`):
 
-Remember the chosen space's `name` (the slug) for the upload call.
+    > **"App Name"** (app_id) is already saved in Nova and you can keep editing
+    > it here anytime — this **also** uploads it as a **new** app to CommCare HQ
+    > at `commcarehq.org/a/<space>/`, using your API key. Your Nova copy stays put.
+    >
+    > Proceed?
 
-## 3. Confirm with the user
-
-Show this before uploading (substitute the real values; `<space>` is the
-chosen space's `name`):
-
-> **"App Name"** (app_id) is already saved in Nova — this upload is not what
-> keeps it safe, you can edit it here anytime.
->
-> Uploading creates a **new** app at `commcarehq.org/a/<space>/` using your
-> API key. Your Nova copy stays put.
->
-> Proceed?
-
-Wait for their confirmation. If they decline, stop.
+    Wait for their confirmation. If they decline, stop.
 
 ## 4. Upload
 
 Call Nova's `upload_app_to_hq` tool with
-`{app_id: "<resolved app_id>", domain: "<chosen space name>"}`.
-
-Always pass `domain` explicitly — it's the space you confirmed in step 3.
-(Omitting it works only for a single-space key; for a multi-space key the tool
-returns `domain_ambiguous` rather than guessing the target.)
+`{app_id: "<resolved app_id>", domain: "<target space slug>"}`. Always pass
+`domain` explicitly — it's the explicit target, or the space resolved and
+confirmed in step 3.
 
 ## 5. Report
 
-On success, the response has `{hq_app_id, url, warnings}`. Tell the user:
+On success the response has `{hq_app_id, url, warnings}`. Report the same way on
+both paths:
 
 > Uploaded **"App Name"** → `<url>`
 >
@@ -75,9 +84,13 @@ On success, the response has `{hq_app_id, url, warnings}`. Tell the user:
 
 On a failed upload, surface `error_type` and `message` from the response:
 
-- `domain_ambiguous` / `domain_not_authorized` → the message names the spaces
-  the key reaches; re-confirm the target with the user and retry step 4 with a
-  valid `domain`.
-- `hq_not_configured` → the user needs to add their key in Settings.
-- `hq_upload_failed` → an HQ-side rejection; show the message so the user knows
-  what HQ rejected.
+- `domain_not_authorized` — the space you passed isn't one the key can reach.
+  The `message` already names every space it CAN reach, so relay that in one
+  turn rather than making the user re-run the command — e.g. "`<space>` isn't
+  connected to your key, but these are: `<list>`. Want me to upload to one of
+  those?" — then upload to their pick.
+- `domain_ambiguous` — only happens with no `domain`; resolve the target via
+  step 3 and retry step 4.
+- `hq_not_configured` — the user needs to add their key in Settings.
+- `hq_upload_failed` — an HQ-side rejection; show the `message` so the user
+  knows what HQ rejected.


### PR DESCRIPTION
Follow-up to #22, from operator feedback.

## Optional project-space argument
`/nova:upload_to_hq <app_id or name> [project space]`. If you name a project space the key can reach, Nova uploads **straight there** — naming the space *is* the confirmation, so it skips the connection lookup and the are-you-sure prompt and just reports the result (same done / HQ link). Omit the space and the existing flow runs: single-space key confirms; multi-space key asks which space, then confirms.

(Skills support multiple args — `argument-hint` is display-only; the body parses an optional trailing domain slug out of `$ARGUMENTS`, with quoting for multi-word app names. Confirmed against the Claude Code skills docs.)

## Wrong-space recovery in one turn
If you pass a space the key can't reach, `upload_app_to_hq` returns `domain_not_authorized` with the reachable set already named in its message. The skill now relays that immediately — "`<space>` isn't connected to your key, but these are: …" — instead of making you re-run. (No commcare-nova change needed; the tool already returns the list.)

## Positive confirm wording
The pre-upload confirmation read backwards — *"this upload is not what keeps it safe."* Flipped to lead with the reassurance: **"already saved in Nova and you can keep editing it here anytime — this also uploads it as a new app to CommCare HQ."** (Only shown when you don't name a space.)

## Also
Bump → **1.1.3** (installed copies need it to get the change). Fixed the stale README line (`/nova:upload <app_id> <domain> [app_name]` → `/nova:upload_to_hq <app_id or name> [project space]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)